### PR TITLE
Add functionality to and improve readability of Monitor example

### DIFF
--- a/examples/Monitor/Monitor.ino
+++ b/examples/Monitor/Monitor.ino
@@ -6,35 +6,35 @@ void cppm_cycle(void)
 	if (CPPM.synchronized())
 	{
         uint32_t previous = micros();
-//	    // good for DX8-R615X
-//	    int aile = (CPPM.read(CPPM_AILE) - 1500*2) / 8 * 125 / 128; // aile -100% .. +100%
-//  	int elev = (CPPM.read(CPPM_ELEV) - 1500*2) / 8 * 125 / 128; // elevator -100% .. +100%
-//  	int thro = (CPPM.read(CPPM_THRO) - 1500*2) / 8 * 125 / 128; // throttle -100% .. +100%
-//  	int rudd = (CPPM.read(CPPM_RUDD) - 1500*2) / 8 * 125 / 128; // rudder -100% .. +100%
-//  	int gear = (CPPM.read(CPPM_GEAR) - 1500*2) / 8 * 125 / 128; // gear -100% .. +100%
-//  	int aux1 = (CPPM.read(CPPM_AUX1) - 1500*2) / 8 * 125 / 128; // flap -100% .. +100%
+//      // good for DX8-R615X
+//      int aile = (CPPM.read(CPPM_AILE) - 1500*2) / 8 * 125 / 128; // aile -100% .. +100%
+//      int elev = (CPPM.read(CPPM_ELEV) - 1500*2) / 8 * 125 / 128; // elevator -100% .. +100%
+//      int thro = (CPPM.read(CPPM_THRO) - 1500*2) / 8 * 125 / 128; // throttle -100% .. +100%
+//      int rudd = (CPPM.read(CPPM_RUDD) - 1500*2) / 8 * 125 / 128; // rudder -100% .. +100%
+//      int gear = (CPPM.read(CPPM_GEAR) - 1500*2) / 8 * 125 / 128; // gear -100% .. +100%
+//      int aux1 = (CPPM.read(CPPM_AUX1) - 1500*2) / 8 * 125 / 128; // flap -100% .. +100%
 
-    	int aile = CPPM.read_us(CPPM_AILE) - 1500; // aile
-    	int elev = CPPM.read_us(CPPM_ELEV) - 1500; // elevator
-    	int thro = CPPM.read_us(CPPM_THRO) - 1500; // throttle
-    	int rudd = CPPM.read_us(CPPM_RUDD) - 1500; // rudder
-    	int gear = CPPM.read_us(CPPM_GEAR) - 1500; // gear
-    	int aux1 = CPPM.read_us(CPPM_AUX1) - 1500; // flap
+        int aile = CPPM.read_us(CPPM_AILE) - 1500; // aile
+        int elev = CPPM.read_us(CPPM_ELEV) - 1500; // elevator
+        int thro = CPPM.read_us(CPPM_THRO) - 1500; // throttle
+        int rudd = CPPM.read_us(CPPM_RUDD) - 1500; // rudder
+        int gear = CPPM.read_us(CPPM_GEAR) - 1500; // gear
+        int aux1 = CPPM.read_us(CPPM_AUX1) - 1500; // flap
         int aux2 = CPPM.read_us(CPPM_AUX2) - 1500; // flap
         int aux3 = CPPM.read_us(CPPM_AUX3) - 1500; // flap
 
         uint32_t now = micros();
         Serial.print("Cycle time: " + (String)(now - previous) + "\t| ");
 
-	    Serial.print(aile); Serial.print(",\t");
-    	Serial.print(elev); Serial.print(",\t");
-    	Serial.print(thro); Serial.print(",\t");
-    	Serial.print(rudd); Serial.print(",\t");
-    	Serial.print(gear); Serial.print(",\t");
+        Serial.print(aile); Serial.print(",\t");
+        Serial.print(elev); Serial.print(",\t");
+        Serial.print(thro); Serial.print(",\t");
+        Serial.print(rudd); Serial.print(",\t");
+        Serial.print(gear); Serial.print(",\t");
         Serial.print(aux1); Serial.print(",\t");
         Serial.print(aux2); Serial.print(",\t");
-	    Serial.print(aux3); Serial.print("\n");
-	    Serial.flush();
+        Serial.print(aux3); Serial.print("\n");
+        Serial.flush();
 	}
 	else
 	{

--- a/examples/Monitor/Monitor.ino
+++ b/examples/Monitor/Monitor.ino
@@ -6,35 +6,35 @@ void cppm_cycle(void)
 	if (CPPM.synchronized())
 	{
         uint32_t previous = micros();
-//		// good for DX8-R615X
-//		int aile = (CPPM.read(CPPM_AILE) - 1500*2) / 8 * 125 / 128; // aile -100% .. +100%
-//		int elev = (CPPM.read(CPPM_ELEV) - 1500*2) / 8 * 125 / 128; // elevator -100% .. +100%
-//		int thro = (CPPM.read(CPPM_THRO) - 1500*2) / 8 * 125 / 128; // throttle -100% .. +100%
-//		int rudd = (CPPM.read(CPPM_RUDD) - 1500*2) / 8 * 125 / 128; // rudder -100% .. +100%
-//		int gear = (CPPM.read(CPPM_GEAR) - 1500*2) / 8 * 125 / 128; // gear -100% .. +100%
-//		int aux1 = (CPPM.read(CPPM_AUX1) - 1500*2) / 8 * 125 / 128; // flap -100% .. +100%
+//	    // good for DX8-R615X
+//	    int aile = (CPPM.read(CPPM_AILE) - 1500*2) / 8 * 125 / 128; // aile -100% .. +100%
+//  	int elev = (CPPM.read(CPPM_ELEV) - 1500*2) / 8 * 125 / 128; // elevator -100% .. +100%
+//  	int thro = (CPPM.read(CPPM_THRO) - 1500*2) / 8 * 125 / 128; // throttle -100% .. +100%
+//  	int rudd = (CPPM.read(CPPM_RUDD) - 1500*2) / 8 * 125 / 128; // rudder -100% .. +100%
+//  	int gear = (CPPM.read(CPPM_GEAR) - 1500*2) / 8 * 125 / 128; // gear -100% .. +100%
+//  	int aux1 = (CPPM.read(CPPM_AUX1) - 1500*2) / 8 * 125 / 128; // flap -100% .. +100%
 
-		int aile = CPPM.read_us(CPPM_AILE) - 1500; // aile
-		int elev = CPPM.read_us(CPPM_ELEV) - 1500; // elevator
-		int thro = CPPM.read_us(CPPM_THRO) - 1500; // throttle
-		int rudd = CPPM.read_us(CPPM_RUDD) - 1500; // rudder
-		int gear = CPPM.read_us(CPPM_GEAR) - 1500; // gear
-		int aux1 = CPPM.read_us(CPPM_AUX1) - 1500; // flap
+    	int aile = CPPM.read_us(CPPM_AILE) - 1500; // aile
+    	int elev = CPPM.read_us(CPPM_ELEV) - 1500; // elevator
+    	int thro = CPPM.read_us(CPPM_THRO) - 1500; // throttle
+    	int rudd = CPPM.read_us(CPPM_RUDD) - 1500; // rudder
+    	int gear = CPPM.read_us(CPPM_GEAR) - 1500; // gear
+    	int aux1 = CPPM.read_us(CPPM_AUX1) - 1500; // flap
         int aux2 = CPPM.read_us(CPPM_AUX2) - 1500; // flap
         int aux3 = CPPM.read_us(CPPM_AUX3) - 1500; // flap
 
         uint32_t now = micros();
         Serial.print("Cycle time: " + (String)(now - previous) + "\t| ");
 
-		Serial.print(aile); Serial.print(",\t");
-		Serial.print(elev); Serial.print(",\t");
-		Serial.print(thro); Serial.print(",\t");
-		Serial.print(rudd); Serial.print(",\t");
-		Serial.print(gear); Serial.print(",\t");
+	    Serial.print(aile); Serial.print(",\t");
+    	Serial.print(elev); Serial.print(",\t");
+    	Serial.print(thro); Serial.print(",\t");
+    	Serial.print(rudd); Serial.print(",\t");
+    	Serial.print(gear); Serial.print(",\t");
         Serial.print(aux1); Serial.print(",\t");
         Serial.print(aux2); Serial.print(",\t");
-		Serial.print(aux3); Serial.print("\n");
-		Serial.flush();
+	    Serial.print(aux3); Serial.print("\n");
+	    Serial.flush();
 	}
 	else
 	{

--- a/examples/Monitor/Monitor.ino
+++ b/examples/Monitor/Monitor.ino
@@ -5,6 +5,7 @@ void cppm_cycle(void)
 {
 	if (CPPM.synchronized())
 	{
+        uint32_t previous = micros();
 //		// good for DX8-R615X
 //		int aile = (CPPM.read(CPPM_AILE) - 1500*2) / 8 * 125 / 128; // aile -100% .. +100%
 //		int elev = (CPPM.read(CPPM_ELEV) - 1500*2) / 8 * 125 / 128; // elevator -100% .. +100%
@@ -19,13 +20,20 @@ void cppm_cycle(void)
 		int rudd = CPPM.read_us(CPPM_RUDD) - 1500; // rudder
 		int gear = CPPM.read_us(CPPM_GEAR) - 1500; // gear
 		int aux1 = CPPM.read_us(CPPM_AUX1) - 1500; // flap
+        int aux2 = CPPM.read_us(CPPM_AUX2) - 1500; // flap
+        int aux3 = CPPM.read_us(CPPM_AUX3) - 1500; // flap
 
-		Serial.print(aile); Serial.print(", ");
-		Serial.print(elev); Serial.print(", ");
-		Serial.print(thro); Serial.print(", ");
-		Serial.print(rudd); Serial.print(", ");
-		Serial.print(gear); Serial.print(", ");
-		Serial.print(aux1); Serial.print("\n");
+        uint32_t now = micros();
+        Serial.print("Cycle time: " + (String)(now - previous) + "\t| ");
+
+		Serial.print(aile); Serial.print(",\t");
+		Serial.print(elev); Serial.print(",\t");
+		Serial.print(thro); Serial.print(",\t");
+		Serial.print(rudd); Serial.print(",\t");
+		Serial.print(gear); Serial.print(",\t");
+        Serial.print(aux1); Serial.print(",\t");
+        Serial.print(aux2); Serial.print(",\t");
+		Serial.print(aux3); Serial.print("\n");
 		Serial.flush();
 	}
 	else


### PR DESCRIPTION
- Use tabs to make output in Serial Monitor more readable
- Add cycle time measurement to measure the time taken to read CPPM values